### PR TITLE
feat:add unit test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,3 +54,4 @@ typing-inspection==0.4.1
 typing_extensions==4.13.2
 urllib3==1.26.20
 uvicorn==0.34.2
+pytest==8.3.4

--- a/test/test_question_cache.py
+++ b/test/test_question_cache.py
@@ -1,0 +1,78 @@
+import pytest
+from app.core.question_cache import QuestionCacheManager
+from datetime import datetime, timedelta
+
+@pytest.fixture
+def cache_manager():
+    """테스트를 위한 새로운 캐시 매니저 인스턴스를 생성"""
+    return QuestionCacheManager(ttl_hours=1, max_questions_per_key=3)
+
+def test_add_and_get_questions(cache_manager):
+    """질문 추가 및 조회가 정상적으로 동작하는지 테스트"""
+    doc_id = "doc1"
+    job = "backend"
+    cat = "tech"
+    level = "hard"
+
+    # 처음에는 비어있어야 함
+    assert cache_manager.get_previous_questions(doc_id, job, cat, level) == []
+
+    # 질문 추가
+    cache_manager.add_question(doc_id, job, cat, level, "질문1")
+    cache_manager.add_question(doc_id, job, cat, level, "질문2")
+
+    # 조회 확인
+    assert cache_manager.get_previous_questions(doc_id, job, cat, level) == ["질문1", "질문2"]
+
+def test_cache_expiration(cache_manager):
+    """캐시 만료 로직이 정상 동작하는지 테스트"""
+    doc_id = "doc2"
+    job = "frontend"
+    cat = "cs"
+    level = "easy"
+
+    cache_manager.add_question(doc_id, job, cat, level, "만료될 질문")
+    
+    # 캐시 엔트리의 만료 시간을 과거로 조작
+    cache_key = cache_manager._generate_cache_key(doc_id, job, cat, level)
+    cache_manager._cache[cache_key]['expires_at'] = datetime.now() - timedelta(hours=2)
+
+    # 만료 후 조회 시 빈 리스트가 반환되어야 함
+    assert cache_manager.get_previous_questions(doc_id, job, cat, level) == []
+    # 내부 캐시에서도 삭제되었는지 확인
+    assert cache_key not in cache_manager._cache
+
+def test_max_questions_limit(cache_manager):
+    """최대 질문 개수 제한이 잘 동작하는지 테스트"""
+    doc_id = "doc3"
+    job = "ai"
+    cat = "project"
+    level = "normal"
+
+    cache_manager.add_question(doc_id, job, cat, level, "질문1")
+    cache_manager.add_question(doc_id, job, cat, level, "질문2")
+    cache_manager.add_question(doc_id, job, cat, level, "질문3")
+    cache_manager.add_question(doc_id, job, cat, level, "질문4") # 여기서 질문1이 밀려나야 함
+
+    questions = cache_manager.get_previous_questions(doc_id, job, cat, level)
+    assert len(questions) == 3
+    assert questions == ["질문2", "질문3", "질문4"]
+
+def test_clear_cache_by_document(cache_manager):
+    """특정 문서 ID의 모든 캐시가 잘 삭제되는지 테스트"""
+    doc_id = "doc4"
+    cache_manager.add_question(doc_id, "job1", "cat1", "level1", "질문A")
+    cache_manager.add_question(doc_id, "job2", "cat2", "level2", "질문B")
+    
+    # 다른 문서 ID의 캐시
+    cache_manager.add_question("another_doc", "job1", "cat1", "level1", "질문C")
+    
+    deleted_count = cache_manager.clear_cache_by_document(doc_id)
+    assert deleted_count == 2
+    
+    # doc4의 캐시들이 삭제되었는지 확인
+    assert cache_manager.get_previous_questions(doc_id, "job1", "cat1", "level1") == []
+    assert cache_manager.get_previous_questions(doc_id, "job2", "cat2", "level2") == []
+    
+    # 다른 문서의 캐시는 남아있는지 확인
+    assert cache_manager.get_previous_questions("another_doc", "job1", "cat1", "level1") == ["질문C"]

--- a/test/test_question_generator.py
+++ b/test/test_question_generator.py
@@ -1,0 +1,35 @@
+import pytest
+from app.interview.question_generator import decide_question_type, generate_questions, fallback_question
+
+def test_decide_question_type():
+    """이전 질문이 없으면 '일반질문'을, 있으면 둘 중 하나를 반환하는지 테스트"""
+    # 첫 질문일 경우
+    assert decide_question_type(None, None) == "일반질문"
+
+    # 이전 질문/답변이 있는 경우 (랜덤이므로 여러 번 테스트하여 확인)
+    results = {decide_question_type("질문1", "답변1") for _ in range(20)}
+    assert "일반질문" in results
+    assert "꼬리질문" in results
+
+def test_generate_questions():
+    """이전 질문 리스트를 올바른 포맷의 문자열로 변환하는지 테스트"""
+    # 이전 질문이 있을 경우
+    questions = ["질문1", "질문2"]
+    expected_text = """
+**이전에 생성된 질문들 (중복 금지):**
+- 질문1
+- 질문2
+
+위 질문들과 겹치지 않는 새로운 관점의 질문을 생성하세요.
+"""
+    assert generate_questions(questions) == expected_text
+
+    # 이전 질문이 없을 경우
+    assert generate_questions([]) == ""
+
+def test_fallback_question():
+    """대체 질문이 올바른 형식으로 반환되는지 테스트"""
+    question_data = fallback_question()
+    assert "questionType" in question_data
+    assert "question" in question_data
+    assert question_data["questionType"] == "일반질문"


### PR DESCRIPTION
## What
AI 서버의 안정성 강화를 위해 `question_cache`와 `question_generator` 모듈에 대한 단위 테스트 코드를 추가.

## Why
핵심 로직인 질문 생성 및 캐시 관리 기능의 예측 가능성을 보장하고, 향후 기능 변경 시 발생할 수 있는 잠재적 버그(회귀)를 사전에 방지하기 위해 테스트 커버리지를 확보.

## Changes
- **`tests/core/test_question_cache.py` 추가**:
  - 질문 추가, 조회, 만료, 개수 제한, 삭제 등 캐시의 핵심 기능 검증
- **`tests/interview/test_question_generator.py` 추가**:
  - 질문 유형 결정, 프롬프트 포맷팅 등 헬퍼 함수의 로직 검증

